### PR TITLE
Fixed a typo in d-setup.org

### DIFF
--- a/d-setup.org
+++ b/d-setup.org
@@ -40,7 +40,7 @@ Why not have a block for flake.nix too?
 
   inputs = {
 
-    # Change it to table, if you want stable channel
+    # Change it to stable, if you want stable channel
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     # Idk where is this used, I just have it


### PR DESCRIPTION
Fixed a typo in d-setup.org in line 43 branch name should be stable instead of table